### PR TITLE
Add kanban and PR review workflow

### DIFF
--- a/.github/ISSUE_TEMPLATE/task.yml
+++ b/.github/ISSUE_TEMPLATE/task.yml
@@ -1,0 +1,52 @@
+name: Task
+description: Track a work item for the mtgSiteWIP kanban board.
+title: "[Task]: "
+labels: []
+body:
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: What needs to change?
+      placeholder: Describe the task in one or two sentences.
+    validations:
+      required: true
+  - type: textarea
+    id: acceptance-criteria
+    attributes:
+      label: Acceptance criteria
+      description: What must be true before this task is done?
+      placeholder: |
+        - [ ] The page or behavior works as expected.
+        - [ ] The change has been reviewed.
+        - [ ] Any related PR links this issue with "Closes #".
+    validations:
+      required: true
+  - type: dropdown
+    id: task-type
+    attributes:
+      label: Type
+      options:
+        - feature
+        - bug
+        - content
+        - design
+        - cleanup
+    validations:
+      required: true
+  - type: dropdown
+    id: priority
+    attributes:
+      label: Priority
+      options:
+        - "priority: normal"
+        - "priority: high"
+        - "priority: low"
+    validations:
+      required: true
+  - type: textarea
+    id: notes
+    attributes:
+      label: Notes
+      description: Links, screenshots, constraints, or implementation notes.
+      placeholder: Add any useful context here.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,17 @@
+## Summary
+
+- 
+
+## Linked issue
+
+Closes #
+
+## Review checklist
+
+- [ ] I reviewed the current branch before opening this PR.
+- [ ] Pages still open locally.
+- [ ] Shared JavaScript has no obvious console/runtime errors.
+- [ ] Navigation and visible content still work.
+- [ ] The working tree was clean before final review.
+
+## Notes for reviewer

--- a/README.md
+++ b/README.md
@@ -1,1 +1,3 @@
 # mtgSiteWIP
+
+See [docs/workflow.md](docs/workflow.md) for the kanban and PR review workflow.

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -1,0 +1,80 @@
+# Kanban and PR Review Workflow
+
+## Kanban
+
+Use GitHub Projects as the visual board and GitHub Issues as the source of truth for tasks.
+
+Recommended board statuses:
+
+- Backlog
+- Ready
+- In Progress
+- Review
+- Done
+
+Recommended issue labels:
+
+- bug
+- feature
+- content
+- design
+- cleanup
+- priority: high
+- priority: normal
+- priority: low
+
+Each task should start as a GitHub Issue with a clear summary, acceptance criteria, type, and priority. Add the issue to the GitHub Project board and move it through the board as work progresses.
+
+## Branches
+
+Use one branch per task when practical.
+
+```bash
+git checkout main
+git pull
+git checkout -b feature/short-task-name
+```
+
+Avoid direct commits to `main` except for tiny administrative changes.
+
+## PR Review
+
+Use two review checkpoints.
+
+Before opening a PR, ask Codex:
+
+```text
+Review my current branch before I open a PR.
+```
+
+Codex should inspect:
+
+- `git status`
+- `git diff main...HEAD`
+- changed files
+- browser or manual behavior when relevant
+
+After opening a PR, ask Codex:
+
+```text
+Review PR #123 in rboles84/mtgSiteWIP.
+```
+
+Codex should review bugs and regressions first, call out file and line-specific findings, note missing verification, and only approve when no blocking issues remain.
+
+## Static Site Checks
+
+For the current static site, each PR should verify:
+
+- Pages still open locally.
+- Shared JavaScript has no obvious console/runtime errors.
+- Navigation and visible content still work.
+- Git working tree is clean before final review.
+
+If project tooling is added later, run the available checks before review, such as:
+
+```bash
+npm test
+npm run lint
+npm run build
+```


### PR DESCRIPTION
## Summary

- Add a GitHub issue form for kanban task intake.
- Add a pull request template with the two-checkpoint review process.
- Document the kanban board, issue labels, branch workflow, and static site review checks.
- Link the workflow from the README.

## Notes

GitHub Projects board creation and repository label creation still need to be completed in GitHub UI or with GitHub CLI because the current connector does not expose full Projects/label setup controls.